### PR TITLE
chore: implement unified address bar focus system with window-specific targeting

### DIFF
--- a/ora/Common/Constants/AppEvents.swift
+++ b/ora/Common/Constants/AppEvents.swift
@@ -16,8 +16,6 @@ extension Notification.Name {
     static let nextTab = Notification.Name("NextTab")
     static let previousTab = Notification.Name("PreviousTab")
     static let toggleToolbar = Notification.Name("ToggleToolbar")
-    static let focusAddressBarRequest = Notification.Name("FocusAddressBarRequest")
-    static let focusAddressBar = Notification.Name("FocusAddressBar")
 
     // Per-window settings/events
     static let setAppearance = Notification.Name("SetAppearance") // userInfo: ["appearance": String]

--- a/ora/Common/Constants/AppEvents.swift
+++ b/ora/Common/Constants/AppEvents.swift
@@ -16,6 +16,8 @@ extension Notification.Name {
     static let nextTab = Notification.Name("NextTab")
     static let previousTab = Notification.Name("PreviousTab")
     static let toggleToolbar = Notification.Name("ToggleToolbar")
+    static let focusAddressBarRequest = Notification.Name("FocusAddressBarRequest")
+    static let focusAddressBar = Notification.Name("FocusAddressBar")
 
     // Per-window settings/events
     static let setAppearance = Notification.Name("SetAppearance") // userInfo: ["appearance": String]

--- a/ora/Common/Constants/AppEvents.swift
+++ b/ora/Common/Constants/AppEvents.swift
@@ -4,6 +4,7 @@ extension Notification.Name {
     static let toggleSidebar = Notification.Name("ToggleSidebar")
     static let copyAddressURL = Notification.Name("CopyAddressURL")
     static let focusAddressBar = Notification.Name("FocusAddressBar")
+    static let openLauncherWithURL = Notification.Name("OpenLauncherWithURL")
 
     static let showLauncher = Notification.Name("ShowLauncher")
     static let closeActiveTab = Notification.Name("CloseActiveTab")

--- a/ora/Common/Constants/AppEvents.swift
+++ b/ora/Common/Constants/AppEvents.swift
@@ -3,6 +3,7 @@ import Foundation
 extension Notification.Name {
     static let toggleSidebar = Notification.Name("ToggleSidebar")
     static let copyAddressURL = Notification.Name("CopyAddressURL")
+    static let focusAddressBar = Notification.Name("FocusAddressBar")
 
     static let showLauncher = Notification.Name("ShowLauncher")
     static let closeActiveTab = Notification.Name("CloseActiveTab")

--- a/ora/Modules/Launcher/LauncherView.swift
+++ b/ora/Modules/Launcher/LauncherView.swift
@@ -15,6 +15,7 @@ struct LauncherView: View {
     @State private var isVisible = false
     @FocusState private var isTextFieldFocused: Bool
     @State private var match: LauncherMain.Match?
+    @State private var isEditingCurrentURL: Bool = false
 
     var clearOverlay: Bool? = false
 
@@ -34,6 +35,14 @@ struct LauncherView: View {
 
     private func onSubmit(_ newInput: String? = nil) {
         let correctInput = newInput ?? input
+
+        if isEditingCurrentURL, let activeTab = tabManager.activeTab {
+            activeTab.loadURL(correctInput)
+            appState.showLauncher = false
+            isEditingCurrentURL = false
+            return
+        }
+
         var engineToUse = match
 
         if engineToUse == nil,
@@ -73,6 +82,7 @@ struct LauncherView: View {
                         isVisible = false
                         DispatchQueue.main.async {
                             appState.showLauncher = false
+                            appState.launcherSearchText = ""
                         }
                     }
                 }
@@ -82,7 +92,8 @@ struct LauncherView: View {
                 match: $match,
                 isFocused: $isTextFieldFocused,
                 onTabPress: onTabPress,
-                onSubmit: onSubmit
+                onSubmit: onSubmit,
+                isEditingCurrentURL: isEditingCurrentURL
             )
             .gradientAnimatingBorder(
                 color: match?.faviconBackgroundColor ?? match?.color ?? .clear,
@@ -97,9 +108,27 @@ struct LauncherView: View {
                 isVisible = true
                 isTextFieldFocused = true
                 searchEngineService.setTheme(theme)
+                if !appState.launcherSearchText.isEmpty {
+                    input = appState.launcherSearchText
+                    isEditingCurrentURL = true
+                    match = nil
+                    appState.launcherSearchText = ""
+                }
             }
             .onChange(of: appState.showLauncher) { _, newValue in
                 isVisible = newValue
+                if newValue {
+                    if !appState.launcherSearchText.isEmpty {
+                        input = appState.launcherSearchText
+                        isEditingCurrentURL = true
+                        match = nil
+                        appState.launcherSearchText = ""
+                    }
+                } else {
+                    input = ""
+                    match = nil
+                    isEditingCurrentURL = false
+                }
             }
             // .onChange(of: theme) { _, newValue in
             //     searchEngineService.setTheme(newValue)
@@ -111,6 +140,8 @@ struct LauncherView: View {
                 isVisible = false
                 DispatchQueue.main.async {
                     appState.showLauncher = false
+                    appState.launcherSearchText = ""
+                    isEditingCurrentURL = false
                 }
             }
         }

--- a/ora/Modules/Launcher/Main/LauncherMain.swift
+++ b/ora/Modules/Launcher/Main/LauncherMain.swift
@@ -42,6 +42,7 @@ struct LauncherMain: View {
     var isFocused: FocusState<Bool>.Binding
     let onTabPress: () -> Void
     let onSubmit: (String?) -> Void
+    var isEditingCurrentURL: Bool = false
 
     @Environment(\.theme) private var theme
     @EnvironmentObject var historyManager: HistoryManager
@@ -121,9 +122,16 @@ struct LauncherMain: View {
         suggestions = []
 
         var itemsCount = 0
-        appendOpenTabs(tabs, itemsCount: &itemsCount)
-        appendOpenURLSuggestionIfNeeded(text)
-        appendSearchWithDefaultEngineSuggestion(text)
+
+        if isEditingCurrentURL {
+            appendOpenTabs(tabs, itemsCount: &itemsCount)
+            appendOpenURLSuggestionIfNeeded(text)
+            appendSearchWithDefaultEngineSuggestion(text)
+        } else {
+            appendOpenURLSuggestionIfNeeded(text)
+            appendSearchWithDefaultEngineSuggestion(text)
+            appendOpenTabs(tabs, itemsCount: &itemsCount)
+        }
 
         let insertIndex = suggestions.count
         requestAutoSuggestions(text, insertAt: insertIndex)
@@ -162,6 +170,8 @@ struct LauncherMain: View {
     }
 
     private func appendOpenURLSuggestionIfNeeded(_ text: String) {
+        if isEditingCurrentURL { return }
+
         guard let candidateURL = URL(string: text) else { return }
         let finalURL: URL? = if candidateURL.scheme != nil {
             candidateURL
@@ -302,7 +312,11 @@ struct LauncherMain: View {
                     font: NSFont.systemFont(ofSize: 18, weight: .medium),
                     onTab: onTabPress,
                     onSubmit: {
-                        executeCommand()
+                        if !suggestions.isEmpty, suggestions.contains(where: { $0.id == focusedElement }) {
+                            executeCommand()
+                        } else {
+                            onSubmit(nil)
+                        }
                     },
                     onDelete: {
                         if text.isEmpty, match != nil {

--- a/ora/Modules/Launcher/Main/LauncherTextField.swift
+++ b/ora/Modules/Launcher/Main/LauncherTextField.swift
@@ -36,6 +36,9 @@ struct LauncherTextField: NSViewRepresentable {
         textField.focusRingType = .none
         textField.drawsBackground = false
         textField.placeholderString = placeholder
+        textField.maximumNumberOfLines = 1
+        textField.cell?.wraps = false
+        textField.cell?.isScrollable = true
         return textField
     }
 

--- a/ora/Modules/Sidebar/SidebarURLDisplay.swift
+++ b/ora/Modules/Sidebar/SidebarURLDisplay.swift
@@ -131,6 +131,10 @@ struct SidebarURLDisplay: View {
         .onReceive(NotificationCenter.default.publisher(for: .copyAddressURL)) { _ in
             triggerCopy(tab.url.absoluteString)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { _ in
+            isEditing = true
+            editingURLString = tab.url.absoluteString
+        }
     }
 
     private func getDisplayURL() -> String {

--- a/ora/Modules/Sidebar/SidebarURLDisplay.swift
+++ b/ora/Modules/Sidebar/SidebarURLDisplay.swift
@@ -12,6 +12,7 @@ struct SidebarURLDisplay: View {
     @FocusState private var isEditing: Bool
     @State private var showCopiedAnimation = false
     @State private var startWheelAnimation = false
+    @State private var window: NSWindow?
 
     init(tab: Tab, editingURLString: Binding<String>) {
         self.tab = tab
@@ -131,10 +132,13 @@ struct SidebarURLDisplay: View {
         .onReceive(NotificationCenter.default.publisher(for: .copyAddressURL)) { _ in
             triggerCopy(tab.url.absoluteString)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { notification in
+            // Only react to notifications from this window
+            guard notification.object as? NSWindow === window else { return }
             isEditing = true
             editingURLString = tab.url.absoluteString
         }
+        .background(WindowReader(window: $window))
     }
 
     private func getDisplayURL() -> String {

--- a/ora/OraCommands.swift
+++ b/ora/OraCommands.swift
@@ -40,7 +40,7 @@ struct OraCommands: Commands {
             .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
 
             Button("Focus Address Bar") {
-                NotificationCenter.default.post(name: .focusAddressBar, object: NSApp.keyWindow)
+                NotificationCenter.default.post(name: .openLauncherWithURL, object: NSApp.keyWindow)
             }
             .keyboardShortcut(KeyboardShortcuts.Address.focus)
         }

--- a/ora/OraCommands.swift
+++ b/ora/OraCommands.swift
@@ -38,6 +38,11 @@ struct OraCommands: Commands {
                 NotificationCenter.default.post(name: .copyAddressURL, object: nil)
             }
             .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
+
+            Button("Focus Address Bar") {
+                NotificationCenter.default.post(name: .focusAddressBarRequest, object: NSApp.keyWindow)
+            }
+            .keyboardShortcut(KeyboardShortcuts.Address.focus)
         }
 
         CommandGroup(replacing: .sidebar) {

--- a/ora/OraCommands.swift
+++ b/ora/OraCommands.swift
@@ -38,6 +38,11 @@ struct OraCommands: Commands {
                 NotificationCenter.default.post(name: .copyAddressURL, object: nil)
             }
             .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
+
+            Button("Focus Address Bar") {
+                NotificationCenter.default.post(name: .focusAddressBar, object: NSApp.keyWindow)
+            }
+            .keyboardShortcut(KeyboardShortcuts.Address.focus)
         }
 
         CommandGroup(replacing: .sidebar) {

--- a/ora/OraCommands.swift
+++ b/ora/OraCommands.swift
@@ -38,11 +38,6 @@ struct OraCommands: Commands {
                 NotificationCenter.default.post(name: .copyAddressURL, object: nil)
             }
             .keyboardShortcut(KeyboardShortcuts.Address.copyURL)
-
-            Button("Focus Address Bar") {
-                NotificationCenter.default.post(name: .focusAddressBarRequest, object: NSApp.keyWindow)
-            }
-            .keyboardShortcut(KeyboardShortcuts.Address.focus)
         }
 
         CommandGroup(replacing: .sidebar) {

--- a/ora/OraRoot.swift
+++ b/ora/OraRoot.swift
@@ -119,6 +119,14 @@ struct OraRoot: View {
                         appState.showLauncher.toggle()
                     }
                 }
+                NotificationCenter.default
+                    .addObserver(forName: .openLauncherWithURL, object: nil, queue: .main) { note in
+                        guard note.object as? NSWindow === window ?? NSApp.keyWindow else { return }
+                        if let activeTab = tabManager.activeTab {
+                            appState.launcherSearchText = activeTab.url.absoluteString
+                            appState.showLauncher = true
+                        }
+                    }
                 NotificationCenter.default.addObserver(forName: .closeActiveTab, object: nil, queue: .main) { note in
                     guard note.object as? NSWindow === window ?? NSApp.keyWindow else { return }
                     tabManager.closeActiveTab()

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -10,6 +10,7 @@ struct URLBar: View {
     @State private var showCopiedAnimation = false
     @State private var startWheelAnimation = false
     @State private var editingURLString: String = ""
+    @State private var window: NSWindow?
     @FocusState private var isEditing: Bool
     @Environment(\.colorScheme) var colorScheme
 
@@ -264,7 +265,9 @@ struct URLBar: View {
                         triggerCopy(activeTab.url.absoluteString)
                     }
                 }
-                .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { _ in
+                .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { notification in
+                    // Only react to notifications from this window
+                    guard notification.object as? NSWindow === window else { return }
                     if let activeTab = tabManager.activeTab {
                         editingURLString = activeTab.url.absoluteString
                         isEditing = true
@@ -274,6 +277,7 @@ struct URLBar: View {
                     Rectangle()
                         .fill(tab.backgroundColor)
                 )
+                .background(WindowReader(window: $window))
             }
         }
     }

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -209,15 +209,6 @@ struct URLBar: View {
                                     )
                             )
                     )
-                    .overlay(
-                        // Hidden button for keyboard shortcut
-                        Button("") {
-                            isEditing = true
-                        }
-                        .keyboardShortcut(KeyboardShortcuts.Address.focus)
-                        .opacity(0)
-                        .allowsHitTesting(false)
-                    )
 
                     ShareLinkButton(
                         isEnabled: true,
@@ -272,6 +263,9 @@ struct URLBar: View {
                     if let activeTab = tabManager.activeTab {
                         triggerCopy(activeTab.url.absoluteString)
                     }
+                }
+                .onReceive(appState.$addressBarFocusRequest) { _ in
+                    isEditing = true
                 }
                 .background(
                     Rectangle()

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -209,6 +209,15 @@ struct URLBar: View {
                                     )
                             )
                     )
+                    .overlay(
+                        // Hidden button for keyboard shortcut
+                        Button("") {
+                            isEditing = true
+                        }
+                        .keyboardShortcut(KeyboardShortcuts.Address.focus)
+                        .opacity(0)
+                        .allowsHitTesting(false)
+                    )
 
                     ShareLinkButton(
                         isEnabled: true,
@@ -263,9 +272,6 @@ struct URLBar: View {
                     if let activeTab = tabManager.activeTab {
                         triggerCopy(activeTab.url.absoluteString)
                     }
-                }
-                .onReceive(appState.$addressBarFocusRequest) { _ in
-                    isEditing = true
                 }
                 .background(
                     Rectangle()

--- a/ora/UI/URLBar.swift
+++ b/ora/UI/URLBar.swift
@@ -209,15 +209,6 @@ struct URLBar: View {
                                     )
                             )
                     )
-                    .overlay(
-                        // Hidden button for keyboard shortcut
-                        Button("") {
-                            isEditing = true
-                        }
-                        .keyboardShortcut(KeyboardShortcuts.Address.focus)
-                        .opacity(0)
-                        .allowsHitTesting(false)
-                    )
 
                     ShareLinkButton(
                         isEnabled: true,
@@ -271,6 +262,12 @@ struct URLBar: View {
                 .onReceive(NotificationCenter.default.publisher(for: .copyAddressURL)) { _ in
                     if let activeTab = tabManager.activeTab {
                         triggerCopy(activeTab.url.absoluteString)
+                    }
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .focusAddressBar)) { _ in
+                    if let activeTab = tabManager.activeTab {
+                        editingURLString = activeTab.url.absoluteString
+                        isEditing = true
                     }
                 }
                 .background(

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -32,8 +32,6 @@ class AppState: ObservableObject {
     @Published var showFullURL: Bool = (UserDefaults.standard.object(forKey: "showFullURL") as? Bool) ?? true {
         didSet { UserDefaults.standard.set(showFullURL, forKey: "showFullURL") }
     }
-
-    @Published var addressBarFocusRequest: UUID = .init()
 }
 
 @main

--- a/ora/oraApp.swift
+++ b/ora/oraApp.swift
@@ -32,6 +32,8 @@ class AppState: ObservableObject {
     @Published var showFullURL: Bool = (UserDefaults.standard.object(forKey: "showFullURL") as? Bool) ?? true {
         didSet { UserDefaults.standard.set(showFullURL, forKey: "showFullURL") }
     }
+
+    @Published var addressBarFocusRequest: UUID = .init()
 }
 
 @main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command + keyboard shortcut to focus the address bar and open the launcher with the current tab’s URL prefilled.
  * Address bar and sidebar now enter per-window edit mode when invoked.
  * Submitting while editing writes the URL directly to the active tab (skips search).

* **Improvements**
  * Launcher suggestions reordered and irrelevant URL suggestions suppressed during URL editing.
  * Launcher input is single-line with horizontal scrolling; input/state reset when launcher closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->